### PR TITLE
Check movement keybinds without hardcode

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,3 +1,4 @@
+using Dalamud.Bindings.ImGui;
 using Dalamud.Game;
 using Dalamud.Game.Command;
 using Dalamud.Game.Config;
@@ -126,7 +127,26 @@ namespace XIVControllerToggle {
         }
 
         private DateTime controllerProcessDelay = DateTime.Now;
+
+        private unsafe bool IsInputActive() {
+            // 1. Check ImGui (Dalamud Plugins)
+            if (ImGui.GetIO().WantCaptureKeyboard) return true;
+
+            // 2. Check Game Chat / Search Bars (The "Native" way)
+            var uiModule = UIModule.Instance();
+            if (uiModule == null) return false;
+
+            var raptureAtkModule = uiModule->GetRaptureAtkModule();
+            if (raptureAtkModule == null) return false;
+
+            // This covers Chat, Party Finder search, Market Board search, etc
+            return raptureAtkModule->AtkModule.IsTextInputActive();
+        }
+
         private unsafe bool IsKeyboardMovement() {
+            // Do nothing if the user has a text input highlighted
+            if (IsInputActive()) return false;
+
             var ks = KeyState;
             var uiInput = UIInputData.Instance();
 

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -131,6 +131,7 @@ namespace XIVControllerToggle {
             var uiInput = UIInputData.Instance();
 
             // Get basic movement keys regardless of what they are set to
+            // Could be customised further in a settings window by storing this elsewhere and adding or removing these based on user settings
             InputId[] movementIds = {
                 InputId.MOVE_FORE,
                 InputId.MOVE_BACK,

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -161,6 +161,7 @@ namespace XIVControllerToggle {
             // No matches
             return false;
         }
+
         private void Update_ProcessKeypresses() {
             // Run every 250ms
             if (DateTime.Now < controllerProcessDelay) return;


### PR DESCRIPTION
With this little bit of code ks[(VK)(int)bind.Key] we cen check any bound key instead of hardcoding WASD.

Currently this looks at moving forwards, back, left, right, or turning; but with some changes to the GUI each of those could be toggled individually fairly easily.

Also added a check to ignore keyboard inputs when a text input is selected.

I think this combined with the ability to bind a macro to a keybind (fairly straight forward to do in vanilla) should be a good step towards #9 Custom keybindings to switch / toggle mode.